### PR TITLE
Support yaml datasets mapping files (in addition to json)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,19 @@ Datasets are specified in a key value manner, where the keys are the dataset ids
 }
 ```
 
+Equivalent yaml is also supported:
+
+```yaml
+---
+
+gfswave_global:
+  path: s3://nextgen-dmac/kerchunk/gfswave_global_kerchunk.json
+  type: kerchunk
+  chunks: {}
+  drop_variables:
+    - orderedSequenceData
+```
+
 Currently `zarr`, `netcdf`, and [`kerchunk`](https://github.com/fsspec/kerchunk) dataset types are supported. This information should be saved a file and specified when running.
 
 ## Building and Deploying Docker Image

--- a/datasets/datasets.yml
+++ b/datasets/datasets.yml
@@ -1,0 +1,24 @@
+cbofs:
+  path: s3://nextgen-dmac-cloud-ingest/nos/cbofs/nos.cbofs.fields.best.nc.zarr
+  type: kerchunk
+  chunks: {}
+  drop_variables:
+    - dstart
+  extensions:
+    vdatum:
+      path: s3://nextgen-dmac-cloud-ingest/nos/vdatums/cbofs_vdatums.nc.zarr
+      water_level_var: zeta
+      vdatum_var: mllwtomsl
+      vdatum_name: mllw
+ciofs:
+  path: s3://nextgen-dmac-cloud-ingest/nos/ciofs/nos.ciofs.fields.best.nc.zarr
+  type: kerchunk
+  chunks: {}
+  drop_variables:
+    - dstart
+  extensions:
+    vdatum:
+      path: s3://nextgen-dmac-cloud-ingest/nos/vdatums/ciofs_vdatums.nc.zarr
+      water_level_var: zeta
+      vdatum_var: mllwtomsl
+      vdatum_name: mllw

--- a/xreds/dataset_provider.py
+++ b/xreds/dataset_provider.py
@@ -1,4 +1,4 @@
-import json
+import yaml
 import datetime
 
 import fsspec
@@ -32,7 +32,9 @@ class DatasetProvider(Plugin):
             fs = fsspec.filesystem("file")
 
         with fs.open(settings.datasets_mapping_file, "r") as f:
-            self.dataset_mapping = json.load(f)
+            #load config using yaml, which can load json or yaml
+            #because yaml is a superset of json
+            self.dataset_mapping = yaml.safe_load(f)
 
     @hookimpl
     def get_datasets(self):


### PR DESCRIPTION
I swapped out the json read for yaml (pyyaml) since it supports both json and yaml, but we could go with the try/except approach, trying json first and yaml second or whatever if that's preferred.