### PR TITLE
Have uvicorn listen on all interfaces

### DIFF
--- a/app.py
+++ b/app.py
@@ -46,4 +46,4 @@ if __name__ == "__main__":
     import uvicorn
 
     # When run directly, run in debug mode
-    uvicorn.run("app:app", port=8090, reload=True, log_level="debug")
+    uvicorn.run("app:app", host="0.0.0.0", port=8090, reload=True, log_level="debug")


### PR DESCRIPTION
Maybe a little niche, but it's nice to be able to run and load xreds remotely. Could also add a note in the docs about setting `UVICORN_HOST` if we don't want to listen to all interfaces by default.