### PR TITLE
Updated configuration for running at higher scale

### DIFF
--- a/k8s/nginx-deployment.yaml
+++ b/k8s/nginx-deployment.yaml
@@ -1,0 +1,82 @@
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-conf
+data:
+  nginx.conf: |
+    events {
+      worker_connections  1024;  ## Default: 1024
+    }
+    http {
+      server {
+        listen   80;
+        server_name nextgen-dev.ioos.us;
+        # example url: http://nlb-nextgen-dev-c6f2020b8ae84ef5.elb.us-east-1.amazonaws.com/assets/index.ce230cd6.css
+        location /xreds/ {
+          sub_filter '/assets'  '/xreds/assets';
+          sub_filter '/datasets'  '/xreds/datasets';
+          sub_filter '/docs'  '/xreds/docs';
+          sub_filter '/export'  '/xreds/export';
+          sub_filter_types *;
+          sub_filter_once off; # ensures it loops through the whole HTML (required)
+          proxy_pass http://xreds-service:8090/;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-Host $host;
+          proxy_set_header X-Forwarded-Port $server_port;
+          proxy_connect_timeout 600s;
+          proxy_send_timeout 600s;
+          proxy_read_timeout 600s;
+        }
+      }
+
+      fastcgi_connect_timeout 600s;
+      fastcgi_send_timeout 600s;
+      fastcgi_read_timeout 600s;
+      keepalive_timeout 600s;
+      send_timeout 600s;
+    }
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.23
+        ports:
+        - containerPort: 80
+        volumeMounts:
+        - mountPath: /etc/nginx # mount nginx-conf volumn to /etc/nginx
+          readOnly: true
+          name: nginx-conf
+      volumes:
+      - name: nginx-conf
+        configMap:
+          name: nginx-conf # place ConfigMap `nginx-conf` on /etc/nginx
+          items:
+            - key: nginx.conf
+              path: nginx.conf
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+spec:
+#  type: LoadBalancer
+  ports:
+  - port: 80
+    targetPort: 80
+  selector:
+    app: nginx

--- a/k8s/nginx-deployment.yaml
+++ b/k8s/nginx-deployment.yaml
@@ -58,7 +58,7 @@ spec:
         ports:
         - containerPort: 80
         volumeMounts:
-        - mountPath: /etc/nginx # mount nginx-conf volumn to /etc/nginx
+        - mountPath: /etc/nginx # mount nginx-conf volume to /etc/nginx
           readOnly: true
           name: nginx-conf
       volumes:

--- a/k8s/xreds.yaml
+++ b/k8s/xreds.yaml
@@ -5,37 +5,52 @@ metadata:
   labels:
     app: xreds
 spec:
-  replicas: 1
+  replicas: 8
   selector:
     matchLabels:
       app: xreds
-
   template:
     metadata:
       labels:
         app: xreds
     spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: "kubernetes.io/hostname"
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              app: xreds
       containers:
-      - name: xreds
-        image: public.ecr.aws/m2c5k9c1/nextgen-dmac/xreds:latest
-        imagePullPolicy: "Always"
-        ports:
-        - containerPort: 8090
-        env:
-        - name: ROOT_PATH
-          value: "/xreds/"
-        - name: EXPORT_THRESHOLD
-          value: "500"
-        - name: WORKERS
-          value: "4"
-        - name: DATASETS_MAPPING_FILE
-          value: "s3://nextgen-dmac/kerchunk/datasets.json"
-        - name: USE_REDIS_CACHE
-          value: "true"
-        - name: REDIS_HOST
-          value: "redis"
-        - name: REDIS_PORT
-          value: "6379"
+        - name: xreds
+          image: public.ecr.aws/m2c5k9c1/nextgen-dmac/xreds:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8090
+          env:
+            - name: ROOT_PATH
+              value: "/xreds/"
+            - name: EXPORT_THRESHOLD
+              value: "500"
+            - name: WORKERS
+              value: "1"
+            - name: DATASETS_MAPPING_FILE
+              value: "s3://nextgen-dmac/kerchunk/datasets.json"
+            - name: MEMORY_CACHE_NUM_DATASETS
+              value: "4"
+            - name: USE_MEMORY_CACHE
+              value: "true"
+            - name: USE_REDIS_CACHE
+              value: "true"
+            - name: REDIS_HOST
+              value: "redis"
+            - name: REDIS_PORT
+              value: "6379"
+          resources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 8Gi
 ---
 apiVersion: v1
 kind: Service
@@ -45,10 +60,8 @@ metadata:
     app: xreds
 spec:
   selector:
-    app.kubernetes.io/name: xreds
-  ports:
-  - protocol: TCP
-    port: 8090
-    targetPort: 8090
-  selector:
     app: xreds
+  ports:
+    - protocol: TCP
+      port: 8090
+      targetPort: 8090


### PR DESCRIPTION
Updated configuration to run more effectively on K8s.

- Changed number of workers per pod to 1 to fix OOM errors from gunicorn
- Set memory limits for pods based on monitoring
- Scaled number of replicas to match new infra
- Added nginx configuration to this repo from nextgen-dmac

Closes #45 