### PR TITLE
Fix Builds and Obstore-Zarr Dataset Loader

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ENV VITE_XREDS_BASE_URL=${ROOT_PATH}
 RUN npm run build
 
 # Build the python service layer
-FROM public.ecr.aws/b1r9q1p5/rps-matplotlib:latest
+FROM public.ecr.aws/b1r9q1p5/rps-matplotlib:python3.12
 
 # Native dependencies
 RUN apt-get update && apt-get install -y \

--- a/xreds/dataset_utils.py
+++ b/xreds/dataset_utils.py
@@ -1,10 +1,8 @@
 import os
 from typing import Optional, Union
 
-import boto3
 import icechunk
 import obstore as obs
-from obstore.auth.boto3 import Boto3CredentialProvider
 import xarray as xr
 import zarr
 
@@ -231,16 +229,9 @@ def _load_zarr_obstore(
     if os.path.exists(dataset_path):
         store = obs.store.LocalStore(dataset_path, mkdir=False)
     else:
-
-        session = boto3.Session(
-            **{k: v for k, v in {
-                "region_name": storage_options.get("region"),
-                "profile_name": storage_options.get("profile"),
-            }.items() if v is not None}
-        )
         store = obs.store.from_url(
             dataset_path,
-            credential_provider=Boto3CredentialProvider(session=session),
+            skip_signature=True,
         )
 
     return xr.open_dataset(


### PR DESCRIPTION
- bumps base python image from 3.11 to 3.12 (to allow for icechunk 2.x support)
- removes boto3 credential provider from zarr-obstore dataset loader function to align with other anonymous dataset loaders